### PR TITLE
Inject the lambda module as an instance rather than path

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,44 +1,31 @@
 // Pseudowrapper for AWS Lambda
-
 var lambdaModule;
 
-var _runner = function(event, callbackFn) {
+var _runner = function(event, callback) {
     if (!lambdaModule) {
-        return callbackFn('Module not initialized', null);
+        return callback('Module not initialized', null);
     }
 
     var lambdacontext = {
         succeed: function(success) {
-            return callbackFn(null, success);
+            return callback(null, success);
         },
         fail: function(error) {
-            return callbackFn(error, null);
+            return callback(error, null);
         }
     };
 
     try {
         lambdaModule.handler(event, lambdacontext);
     } catch (ex) {
-        callbackFn('Exception:' + ex.toString());
+        callback('Exception:' + ex.toString());
     }
 };
 
 // Public interface for the module
 module.exports = exports = {
-    init: function(modName) {
-        if (!modName) {
-            modName = '';
-        }
-
-        try {
-            lambdaModule = require(modName);
-            return this;
-        } catch (ex) {
-            lambdaModule = require(process.cwd() + '/' + modName);
-            return this;
-        }
-
-        return null;
+    init: function(mod) {
+        lambdaModule = mod;
     },
     run: _runner
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda-wrapper",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Wrapper for running Amazon Lambda modules locally",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I think it's better to inject the module as an instance rather than path, as it gives more freedom on where the required lambda function is. I failed to use the current API, when lambda-wrapper was included as a normal NPM module.

In addition, I cleaned up some variable names & spacing. Since it'll break the existing APIs, I bumped the version number, too.
