### PR TITLE
Add context object to run function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
 - '4.3.2'
+- '6.10.0'
 script:
 - npm run unit-tests

--- a/index.js
+++ b/index.js
@@ -67,8 +67,14 @@ class Wrapped {
     });
   }
 
-  run(event, callback) {
-    return this.runHandler(event, {}, callback);
+  run(event, context, callback) {
+    let callbackFunction = callback;
+    if (typeof(context) === 'function') {
+      // backwards compability
+      callbackFunction = context;
+    }
+    const contextObject = context || {};
+    return this.runHandler(event, contextObject, callbackFunction);
   }
 }
 
@@ -91,15 +97,21 @@ module.exports = exports = {
   init: (mod, options) => {
     latest = wrap(mod, options);
   },
-  run: (event, callback) => new Promise((resolve, reject) => {
+  run: (event, context, callback) => new Promise((resolve, reject) => {
+    let callbackFunction = callback;
+    if (typeof(context) === 'function') {
+      // backwards compability
+      callbackFunction = context;
+    }
+    const contextObject = context || {};
     if (typeof latest === typeof undefined) {
       const error = 'Module not initialized';
       reject(error);
-      return callback(error, null);
+      return callbackFunction(error, null);
     }
-    return latest.run(event, (err, data) => {
-      if (callback) {
-        return callback(err, data);
+    return latest.run(event, contextObject, (err, data) => {
+      if (callbackFunction) {
+        return callbackFunction(err, data);
       }
       if (err) {
         return reject(err);

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ class Wrapped {
   run(event, context, callback) {
     let callbackFunction = callback;
     let contextObject = context;
-    if (typeof(context) === 'function') {
+    if (typeof context === 'function') {
       // backwards compability
       callbackFunction = context;
       contextObject = {};
@@ -100,11 +100,12 @@ module.exports = exports = {
   },
   run: (event, context, callback) => new Promise((resolve, reject) => {
     let callbackFunction = callback;
-    if (typeof(context) === 'function') {
+    let contextObject = context;
+    if (typeof context === 'function') {
       // backwards compability
       callbackFunction = context;
+      contextObject = {};
     }
-    const contextObject = context || {};
     if (typeof latest === typeof undefined) {
       const error = 'Module not initialized';
       reject(error);

--- a/index.js
+++ b/index.js
@@ -69,11 +69,12 @@ class Wrapped {
 
   run(event, context, callback) {
     let callbackFunction = callback;
+    let contextObject = context;
     if (typeof(context) === 'function') {
       // backwards compability
       callbackFunction = context;
+      contextObject = {};
     }
-    const contextObject = context || {};
     return this.runHandler(event, contextObject, callbackFunction);
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda-wrapper",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Wrapper for running Amazon Lambda modules locally",
   "main": "index.js",
   "scripts": {
@@ -31,6 +31,5 @@
     "chai": "3.5.0",
     "mocha": "2.4.5"
   },
-  "dependencies": {
-  }
+  "dependencies": {}
 }

--- a/test/test-wrapper.js
+++ b/test/test-wrapper.js
@@ -182,6 +182,26 @@ describe('lambda-wrapper local', () => {
       })
       .catch(done);
   });
+
+  it('wrap + run module 5 (custom context) - callback', (done) => {
+    const w = wrapper.wrap(testMod5);
+
+    w.run({ test: 'cbsuccess' }, { functionName: 'testing' }, (err, response) => {
+      expect(response.test).to.be.equal('testing');
+      done();
+    });
+  });
+
+  it('wrap + run module 5 (custom context) - promise', (done) => {
+    const w = wrapper.wrap(testMod5);
+
+    w.run({ test: 'cbsuccess' }, { functionName: 'testing' })
+      .then((response) => {
+        expect(response.test).to.be.equal('testing');
+        done();
+      })
+      .catch(done);
+  });
 });
 
 if (process.env.RUN_LIVE) {


### PR DESCRIPTION
When writing tests using the serverless mocha plugin, a context object is sometimes needed. For example, `context.awsRequestId` and `context.lambdaName` could be passed forward when using CloudWatch logs as an event trigger (see [AWS Splunk blueprint](http://dev.splunk.com/view/event-collector/SP-CAAAE7Z)).

Closes #8 