### PR TITLE
Introduce input validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,11 @@ class Wrapped {
 
     if (mod[handler]) {
       this.handler = mod[handler];
+    } else {
+      if (!this.lambdaModule.lambdaFunction) {
+        throw new Error("Invalid input. Expected either lambda module (with exposed handler) " +
+          "or AWS Lambda configuration (with provided 'lambdaFunction' name)");
+      }
     }
   }
 


### PR DESCRIPTION
Currently if handler is not found on input object, then without further validation direct AWS call are made, which in turn may produce ambigous errors (from AWS side: either about credentials missing or missing FunctionName in params) when expected outcome was that lambda is run locally.

This patch introduces some sanity validation at initialization level.


