### PR TITLE
Making aws-sdk a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,10 @@
   },
   "homepage": "https://github.com/SC5/lambda-wrapper",
   "devDependencies": {
-    "aws-sdk": "^2.4.0",
     "chai": "3.5.0",
     "mocha": "2.4.5"
   },
-  "dependencies": {}
+  "dependencies": {
+    "aws-sdk": "^2.4.0"
+  }
 }


### PR DESCRIPTION
It appears aws-sdk is not a dev dependency...