### PR TITLE
Add support for async wrapped handlers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: node_js
 node_js:
 - '4.3.2'
 - '6.10.0'
+- '8.11.1'
 script:
 - npm run unit-tests

--- a/test/async/async-wrapper.js
+++ b/test/async/async-wrapper.js
@@ -1,0 +1,44 @@
+"use strict";
+
+const wrapper = require("../../index.js");
+const expect = require("chai").expect;
+
+const testMod7 = {
+  handler: async (event, context) => {
+    if (event.test === "success") {
+      return "Success";
+    }
+    if (event.test === "fail") {
+      throw new Error("Fail");
+    }
+  }
+};
+
+describe("lambda wrapper local async", () => {
+  it("wrap + run async module 7 - await", async () => {
+    const w = wrapper.wrap(testMod7);
+
+    const response = await w.run({ test: "success" });
+    expect(response).to.be.equal("Success");
+  });
+
+  it("wrap + run async module 7 - promise", done => {
+    const w = wrapper.wrap(testMod7);
+
+    w.run({ test: "success" }).then(response => {
+        expect(response).to.be.equal("Success");
+        done();
+      }).catch(done);
+  });
+
+  it("wrap + run async module 7 - exception", async () => {
+    const w = wrapper.wrap(testMod7);
+
+    try {
+      const response = await w.run({ test: "fail" });
+      expect(response).to.be.null;
+    } catch (err) {
+      expect(err).to.be.instanceof(Error);
+    }
+  });
+});

--- a/test/test-wrapper.js
+++ b/test/test-wrapper.js
@@ -227,45 +227,7 @@ describe('lambda-wrapper local', () => {
   });
 
   if (SUPPORTS_ASYNC) {
-    const testMod7 = {
-      handler: async (event, context) => {
-        if (event.test === 'success') {
-          return 'Success';
-        }
-        if (event.test === 'fail') {
-          throw new Error('Fail');
-        }
-      }
-    };
-
-    it('wrap + run async module 7 - await', async () => {
-      const w = wrapper.wrap(testMod7);
-
-      const response = await w.run({test: 'success'});
-      expect(response).to.be.equal('Success');
-    });
-
-    it('wrap + run async module 7 - promise', (done) => {
-      const w = wrapper.wrap(testMod7);
-  
-      w.run({test: 'success'})
-        .then((response) => {
-          expect(response).to.be.equal('Success');
-          done();
-        })
-        .catch(done);
-    });
-
-    it('wrap + run async module 7 - exception', async () => {
-      const w = wrapper.wrap(testMod7);
-
-      try {
-       const response = await w.run({test: 'fail'});
-       expect(response).to.be.null;
-      } catch(err) {
-        expect(err).to.be.instanceof(Error);
-      }
-    });
+    require('./async/async-wrapper');
   }
 });
 


### PR DESCRIPTION
This adds some basic support for Node v8 in that it will check if there was a returned result from the wrapped handler and, if that result is also a promise, it will avoid the scenario of returning nested promises.

I tried to add some test coverage that seemed to follow a similar pattern as to the existing tests, but they should only execute when tested with node v8 or up (as they rely upon the async/await features).